### PR TITLE
Feature: Faster Handling of Up-To-Date Files

### DIFF
--- a/scripts/pmbuild.py
+++ b/scripts/pmbuild.py
@@ -718,7 +718,10 @@ def expand_rules_files(export_config, task_name, subdir):
 
 
 # look for export.json in directory tree, combine and override exports by depth, override further by rules
+cached_export_configs = {}
 def export_config_for_directory(task_name, directory):
+    if task_name not in cached_export_configs:
+        cached_export_configs[task_name] = {}
     file_path = util.sanitize_file_path(directory)
     dirt_tree = file_path.split(os.sep)
     export_dict = dict()
@@ -733,8 +736,12 @@ def export_config_for_directory(task_name, directory):
         subdir = os.path.join(subdir, dirt_tree[i])
         export = os.path.join(subdir, "export.jsn")
         if os.path.exists(export):
-            dir_export_config = jsn.loads(open(export, "r").read())
-            expand_rules_files(dir_export_config, task_name, subdir)
+            if export in cached_export_configs[task_name]:
+                dir_export_config = cached_export_configs[task_name][export]
+            else:
+                dir_export_config = jsn.loads(open(export, "r").read())
+                expand_rules_files(dir_export_config, task_name, subdir)
+                cached_export_configs[task_name][export] = dir_export_config
             util.merge_dicts(export_dict, dir_export_config)
     return export_dict
 


### PR DESCRIPTION
I've noticed during data builds, that when handling files that don't need updating, the process takes a lot longer than you'd expect it to take to check a file's dependencies and skip it. I dug around a bit to see what the cause might be and found that what was taking up the vast majority of the time was loading the jsn export configs for each file over and over again. I modified the setup to cache task exports and re-use them, so we aren't loading the same data repeatedly for each file that gets processed. After doing this I noticed a large increase in performance when handling files, especially long runs of up-to-date files. This will be quite useful for us as often data builds only update a portion of the files.

I ran a local data build of the examples project with all files up-to-date, both with and without the caching of export configs, and these were the results:

`Caching Off : 197170ms`
`Caching On  :  33688ms`

I'm not sure what you think of the implementation, as it is currently using a global variable (which I don't think are used anywhere else in pmbuild) to store the cached configs, so it might need some tweaking, but I think this will be a worthwhile change to get in for the performance boost.